### PR TITLE
Small changes to worldgen registration to help a bit

### DIFF
--- a/src/main/java/androsa/gaiadimension/GaiaDimensionMod.java
+++ b/src/main/java/androsa/gaiadimension/GaiaDimensionMod.java
@@ -53,7 +53,6 @@ public class GaiaDimensionMod {
     public static final ITag.INamedTag<Block> STATIC = BlockTags.makeWrapperTag(new ResourceLocation(MODID, "base_stone_static").toString());
 
     public GaiaDimensionMod() {
-        new GaiaBiomeFeatures(); //This just works
 
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::setup);
@@ -72,7 +71,6 @@ public class GaiaDimensionMod {
 //      ModParticles.PARTICLE_TYPES.register(modEventBus);
         ModRecipes.RECIPE_SERIALIZERS.register(modEventBus);
         ModTileEntities.TILE_ENTITIES.register(modEventBus);
-//      ModWorldgen.FEATURES.register(modEventBus);
 //      ModWorldgen.STRUCTURE_FEATURES.register(modEventBus);
 //      ModWorldgen.SURFACE_BUILDERS.register(modEventBus);
 //      ModWorldgen.WORLD_CARVERS.register(modEventBus);
@@ -89,13 +87,15 @@ public class GaiaDimensionMod {
         event.enqueueWork(() -> {
             PointOfInterestType.registerBlockStates(ModDimensions.GAIA_PORTAL);
             PointOfInterestType.BLOCKS_OF_INTEREST.addAll(ModDimensions.GAIA_PORTAL.blockStates);
+
+            // needs to be in enqueue as vanilla WorldGen registry maps arent threadsafe.
+            GaiaBiomeFeatures.registerConfiguredWorldgen();
+            ModDimensions.initDimension();
+            ModWorldgen.StructureTypes.init();
         });
-        GaiaBiomeFeatures.registerConfiguredWorldgen();
         ModBlocks.addPlants();
         ModEntities.registerSpawnPlacement();
         ModEntities.registerAttributes();
-        ModDimensions.initDimension();
-        ModWorldgen.StructureTypes.init();
         ModBiomes.addBiomeTypes();
     }
 

--- a/src/main/java/androsa/gaiadimension/registry/ModBiomes.java
+++ b/src/main/java/androsa/gaiadimension/registry/ModBiomes.java
@@ -9,30 +9,32 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.function.Supplier;
+
 import static net.minecraftforge.common.BiomeDictionary.*;
 
 public class ModBiomes {
 
     public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(ForgeRegistries.BIOMES, GaiaDimensionMod.MODID);
 
-    public static final RegistryKey<Biome> pink_agate_forest = registerBiome("pink_agate_forest", GaiaBiomes.makePinkAgateForest());
-    public static final RegistryKey<Biome> blue_agate_taiga = registerBiome("blue_agate_taiga", GaiaBiomes.makeBlueAgateTaiga());
-    public static final RegistryKey<Biome> green_agate_jungle = registerBiome("green_agate_jungle", GaiaBiomes.makeGreenAgateJungle());
-    public static final RegistryKey<Biome> purple_agate_swamp = registerBiome("purple_agate_swamp", GaiaBiomes.makePurpleAgateSwamp());
-    public static final RegistryKey<Biome> fossil_woodland = registerBiome("fossil_woodland", GaiaBiomes.makeFossilWoodland());
-    public static final RegistryKey<Biome> mutant_agate_wildwood = registerBiome("mutant_agate_wildwood", GaiaBiomes.makeMutantAgateWildwood());
-    public static final RegistryKey<Biome> volcanic_lands = registerBiome("volcanic_lands", GaiaBiomes.makeVolcanicLands());
-    public static final RegistryKey<Biome> static_wasteland = registerBiome("static_wasteland", GaiaBiomes.makeStaticWasteland());
-    public static final RegistryKey<Biome> goldstone_lands = registerBiome("goldstone_lands", GaiaBiomes.makeGoldstoneLands());
-    public static final RegistryKey<Biome> crystal_plains = registerBiome("crystal_plains", GaiaBiomes.makeCrystalPlains());
-    public static final RegistryKey<Biome> salt_dunes = registerBiome("salt_dunes", GaiaBiomes.makeSaltDunes());
-    public static final RegistryKey<Biome> shining_grove = registerBiome("shining_grove", GaiaBiomes.makeShiningGrove());
-    public static final RegistryKey<Biome> smoldering_bog = registerBiome("smoldering_bog", GaiaBiomes.makeSmolderingBog());
-    public static final RegistryKey<Biome> mineral_reservoir = registerBiome("mineral_reservoir", GaiaBiomes.makeMineralReservoir());
-    public static final RegistryKey<Biome> mineral_river = registerBiome("mineral_river", GaiaBiomes.makeMineralRiver());
+    public static final RegistryKey<Biome> pink_agate_forest = registerBiome("pink_agate_forest", GaiaBiomes::makePinkAgateForest);
+    public static final RegistryKey<Biome> blue_agate_taiga = registerBiome("blue_agate_taiga", GaiaBiomes::makeBlueAgateTaiga);
+    public static final RegistryKey<Biome> green_agate_jungle = registerBiome("green_agate_jungle", GaiaBiomes::makeGreenAgateJungle);
+    public static final RegistryKey<Biome> purple_agate_swamp = registerBiome("purple_agate_swamp", GaiaBiomes::makePurpleAgateSwamp);
+    public static final RegistryKey<Biome> fossil_woodland = registerBiome("fossil_woodland", GaiaBiomes::makeFossilWoodland);
+    public static final RegistryKey<Biome> mutant_agate_wildwood = registerBiome("mutant_agate_wildwood", GaiaBiomes::makeMutantAgateWildwood);
+    public static final RegistryKey<Biome> volcanic_lands = registerBiome("volcanic_lands", GaiaBiomes::makeVolcanicLands);
+    public static final RegistryKey<Biome> static_wasteland = registerBiome("static_wasteland", GaiaBiomes::makeStaticWasteland);
+    public static final RegistryKey<Biome> goldstone_lands = registerBiome("goldstone_lands", GaiaBiomes::makeGoldstoneLands);
+    public static final RegistryKey<Biome> crystal_plains = registerBiome("crystal_plains", GaiaBiomes::makeCrystalPlains);
+    public static final RegistryKey<Biome> salt_dunes = registerBiome("salt_dunes", GaiaBiomes::makeSaltDunes);
+    public static final RegistryKey<Biome> shining_grove = registerBiome("shining_grove", GaiaBiomes::makeShiningGrove);
+    public static final RegistryKey<Biome> smoldering_bog = registerBiome("smoldering_bog", GaiaBiomes::makeSmolderingBog);
+    public static final RegistryKey<Biome> mineral_reservoir = registerBiome("mineral_reservoir", GaiaBiomes::makeMineralReservoir);
+    public static final RegistryKey<Biome> mineral_river = registerBiome("mineral_river", GaiaBiomes::makeMineralRiver);
 
-    private static RegistryKey<Biome> registerBiome(String name, Biome biome) {
-        BIOMES.register(name, () -> biome);
+    private static RegistryKey<Biome> registerBiome(String name, Supplier<Biome> biomeSupplier) {
+        BIOMES.register(name, biomeSupplier);
         return RegistryKey.getOrCreateKey(Registry.BIOME_KEY, new ResourceLocation(GaiaDimensionMod.MODID, name));
     }
 


### PR DESCRIPTION
I moved the ConfiguredWorldgen stuff to enqueueWork to prevent any issues as those registries are not threadsafe. 
I also made the biome registration now properly use suppliers to prevent classloading issues.

However, the real goal of this PR was suppose to be me figuring out why the ConfiguredFeatures I get from Gaia's biomes are not the same ones as the ones registered. In World Blender mod, I grab the biomes from the DynamicRegistry in MinecraftServer's init's but for some reason, my mod detects that Gaia's ConfiguredFeature isn't registered and thus, refuses to import it to prevent mod conflicts down the road.

But what is strange is Gaia's ConfiguredFeatures are registered and do show up in the DynamicRegistry and WorldGenRegistries. Except it is not the same __instance__ of the ConfiguredFeature which is why the registries cannot find the ID of the ConfiguredFeature I grabbed. I am stumped on this myself. Maybe you could ask Oh The Biomes You'll Go devs in case they might know what's up. They do code based biomes as well so they might had ran into this issue before and solved it (World Blender works with BYG just fine)

Here's a picture of what I mean.
![Untitled](https://user-images.githubusercontent.com/40846040/104384512-98b00c00-54ff-11eb-888d-542a7f0b9279.png)


At the very least, I hope this small PR does help with the registration just a tiny bit